### PR TITLE
refactor(store): use broadcast

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "license": "GPL-3.0-only",
       "workspaces": [
         "packages/base",
+        "packages/broadcast",
         "packages/components",
         "packages/forms",
         "packages/store",
@@ -441,18 +442,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
-      "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -969,19 +958,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@redux-devtools/extension": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@redux-devtools/extension/-/extension-3.3.0.tgz",
-      "integrity": "sha512-X34S/rC8S/M1BIrkYD1mJ5f8vlH0BDqxXrs96cvxSBo4FhMdbhU+GUGsmNYov1xjSyLMHgo8NYrUG8bNX7525g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "immutable": "^4.3.4"
-      },
-      "peerDependencies": {
-        "redux": "^3.1.0 || ^4.0.0 || ^5.0.0"
-      }
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1008,6 +984,10 @@
     },
     "node_modules/@torthu/jacketui-base": {
       "resolved": "packages/base",
+      "link": true
+    },
+    "node_modules/@torthu/jacketui-broadcast": {
+      "resolved": "packages/broadcast",
       "link": true
     },
     "node_modules/@torthu/jacketui-components": {
@@ -2117,12 +2097,6 @@
       "engines": {
         "node": ">=10.17.0"
       }
-    },
-    "node_modules/immutable": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.7.tgz",
-      "integrity": "sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==",
-      "license": "MIT"
     },
     "node_modules/import-local": {
       "version": "3.2.0",
@@ -3538,19 +3512,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "license": "MIT"
     },
-    "node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
-    },
     "node_modules/regexparam": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/regexparam/-/regexparam-3.0.0.tgz",
@@ -4412,6 +4373,15 @@
         "tailwind-merge": "*"
       }
     },
+    "packages/broadcast": {
+      "name": "@torthu/jacketui-broadcast",
+      "version": "0.1.0",
+      "license": "GPL-3.0-only",
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "jest": "^29.7.0"
+      }
+    },
     "packages/components": {
       "name": "@torthu/jacketui-components",
       "version": "0.2.1",
@@ -4466,10 +4436,10 @@
     },
     "packages/store": {
       "name": "@torthu/jacketui-store",
-      "version": "0.1.0",
+      "version": "0.3.2",
       "license": "GPL-3.0-only",
       "dependencies": {
-        "@redux-devtools/extension": "^3.3.0"
+        "@torthu/jacketui-broadcast": "^0.1.0"
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@torthu/jacketui-store",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "Simple Store implementation",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -24,6 +24,9 @@
     "url": "https://thune.io"
   },
   "license": "GPL-3.0-only",
+  "dependencies": {
+    "@torthu/jacketui-broadcast": "^0.1.0"
+  },
   "devDependencies": {
     "@types/jest": "^29.5.14",
     "@types/react": "19.0.9",

--- a/packages/store/src/Store.ts
+++ b/packages/store/src/Store.ts
@@ -1,7 +1,16 @@
+import {
+  Broadcast,
+  BroadcastCallbackFunction,
+} from "@torthu/jacketui-broadcast";
 import { referenceComparison } from "./comparison/referenceComparison";
 import { isAsyncActionHandler, isSyncActionHandler } from "./guards";
 import { ActionHandler } from "./types/ActionHandler";
 import { BasicAction } from "./types/BasicAction";
+import { OnPreDataChangedAction } from "./types/StoreBroadcastAction";
+import {
+  OnDataChangedAction,
+  StoreBroadcastAction,
+} from "./types/StoreBroadcastAction";
 
 interface StateChangedCallback<State> {
   (getState: () => State): void;
@@ -24,11 +33,8 @@ interface StoreConstructorProps<State, Action> {
 export class Store<State extends object, Action extends BasicAction> {
   private _actionHandlers: ActionHandler<State, Action>[];
   private _state: State;
-  private _stateChangedCallbacks: StateChangedCallback<State>[];
-  private _preStateChangedCallbacks: StateAboutToChangeCallback<
-    State,
-    Action
-  >[];
+  private _broadcast: Broadcast<StoreBroadcastAction<State, Action>>;
+
   private _compareFunction: (oldState: State, newState: State) => boolean;
 
   /** cloneDeep
@@ -122,11 +128,12 @@ export class Store<State extends object, Action extends BasicAction> {
    * @param {StateAboutToChangeCallback<State>} callback
    * @return {StateAboutToChangeCallback<State>}
    */
-  public onPreDataChanged(
-    callback: StateAboutToChangeCallback<State, Action>
-  ): StateAboutToChangeCallback<State, Action> {
-    this._preStateChangedCallbacks.push(callback);
-    return callback;
+  public onPreDataChanged(callback: StateAboutToChangeCallback<State, Action>) {
+    return this._broadcast.on("preDataChanged", (e) => {
+      if (e.action.type === "preDataChanged") {
+        callback(e.action.payload.state, e.action.payload.action);
+      }
+    });
   }
 
   /** offPreDataChanged(callback)
@@ -134,14 +141,8 @@ export class Store<State extends object, Action extends BasicAction> {
    *
    * @param {StateAboutToChangeCallback<State>} callback
    */
-  public offPreDataChanged(
-    callback: StateAboutToChangeCallback<State, Action>
-  ): void {
-    const index = this._preStateChangedCallbacks.indexOf(callback);
-
-    if (index >= 0) {
-      this._preStateChangedCallbacks.splice(index, 1);
-    }
+  public offPreDataChanged(callback: BroadcastCallbackFunction<any>): void {
+    this._broadcast.off("preDataChanged", callback);
   }
 
   /** onDataChanged(callback)
@@ -150,11 +151,12 @@ export class Store<State extends object, Action extends BasicAction> {
    * @param {StateChangedCallback<State>} callback
    * @return {StateChangedCallback<State>}
    */
-  public onDataChanged(
-    callback: StateChangedCallback<State>
-  ): StateChangedCallback<State> {
-    this._stateChangedCallbacks.push(callback);
-    return callback;
+  public onDataChanged(callback: StateChangedCallback<State>) {
+    return this._broadcast.on("dataChanged", (e) => {
+      if (e.action.type === "dataChanged") {
+        callback(this.getState);
+      }
+    });
   }
 
   /** offDataChanged(callback)
@@ -162,12 +164,8 @@ export class Store<State extends object, Action extends BasicAction> {
    *
    * @param callback StateChangedCallback<State>
    */
-  public offDataChanged(callback: StateChangedCallback<State>): void {
-    const index = this._stateChangedCallbacks.indexOf(callback);
-
-    if (index >= 0) {
-      this._stateChangedCallbacks.splice(index, 1);
-    }
+  public offDataChanged(callback: BroadcastCallbackFunction<any>): void {
+    this._broadcast.off("dataChanged", callback);
   }
 
   /** getState()
@@ -193,9 +191,7 @@ export class Store<State extends object, Action extends BasicAction> {
   public setState(newState: State, cloneDeep: boolean = false): State {
     if (this._isNewState(newState)) {
       this._state = cloneDeep ? Store.cloneDeep(newState) : newState;
-      this._stateChangedCallbacks.forEach((callback) =>
-        callback(this.getState)
-      );
+      this._broadcast.emit({ type: "dataChanged" });
     }
 
     return this._state;
@@ -214,17 +210,19 @@ export class Store<State extends object, Action extends BasicAction> {
       (actionHandler: ActionHandler<State, Action>) => {
         if (isAsyncActionHandler(actionHandler)) {
           const commit = (newState: State, cloneDeep?: boolean) => {
-            this._preStateChangedCallbacks.forEach((callback) =>
-              callback(newState, action)
-            );
+            this._broadcast.emit({
+              type: "preDataChanged",
+              payload: { state: newState, action },
+            });
             this.setState(newState, cloneDeep);
           };
           actionHandler(this.getState, action, commit, this.dispatch);
         } else if (isSyncActionHandler(actionHandler)) {
           const newState = actionHandler(this.getState(), action);
-          this._preStateChangedCallbacks.forEach((callback) =>
-            callback(newState, action)
-          );
+          this._broadcast.emit({
+            type: "preDataChanged",
+            payload: { state: newState, action },
+          });
           this.setState(newState);
         }
       }
@@ -243,11 +241,12 @@ export class Store<State extends object, Action extends BasicAction> {
   }
 
   constructor(props: StoreConstructorProps<State, Action>) {
-    this._stateChangedCallbacks = [];
+    this._broadcast = new Broadcast<StoreBroadcastAction<State, Action>>();
+
     if (props.onStateChanged) {
-      this._stateChangedCallbacks.push(props.onStateChanged);
+      this.onDataChanged(props.onStateChanged);
     }
-    this._preStateChangedCallbacks = [];
+
     this._compareFunction = props.compareFunction || referenceComparison;
     this._actionHandlers = props.actionHandlers;
 

--- a/packages/store/src/types/StoreBroadcastAction.ts
+++ b/packages/store/src/types/StoreBroadcastAction.ts
@@ -1,0 +1,12 @@
+export type OnPreDataChangedAction<State, Action> = {
+  type: "preDataChanged";
+  payload: { state: State; action: Action };
+};
+
+export type OnDataChangedAction = {
+  type: "dataChanged";
+};
+
+export type StoreBroadcastAction<State, Action> =
+  | OnPreDataChangedAction<State, Action>
+  | OnDataChangedAction;


### PR DESCRIPTION
Store now uses jacketui-broadcast for emitting events instead of keeping track of its own internal events.