### PR TITLE
chore(bring): Export type BringInitDecorator

### DIFF
--- a/packages/bring/src/index.ts
+++ b/packages/bring/src/index.ts
@@ -5,3 +5,4 @@ export * from "./request-builder-pipe";
 export * from "./response-pipe";
 
 export type { BringInit } from "./types/BringInit";
+export type { BringInitDecorator } from "./types/BringDecorator";


### PR DESCRIPTION
Exposes BringInitDecorator for use in external decorator function definitions.